### PR TITLE
do not modify the original options object

### DIFF
--- a/autodeebee.js
+++ b/autodeebee.js
@@ -33,7 +33,7 @@ module.exports = class Autodeebee {
   }
 
   sub (name) {
-    const opts = this.opts
+    const opts = { ...this.opts }
     opts.sub = true
     const auto = new Autodeebee(this.autobase, opts)
     auto.bee = this.bee.sub(name)


### PR DESCRIPTION
this was leading to a bug in my project where a second autodeebee I was creating had the default opts object corrupted, making the autobase never get started